### PR TITLE
[refactor] Move the 'routerMiddleware' to the last

### DIFF
--- a/packages/dva/src/index.js
+++ b/packages/dva/src/index.js
@@ -18,8 +18,8 @@ export default function (opts = {}) {
     },
     setupMiddlewares(middlewares) {
       return [
-        routerMiddleware(history),
         ...middlewares,
+        routerMiddleware(history),
       ];
     },
     setupApp(app) {


### PR DESCRIPTION
Move the 'routerMiddleware' to the last of middleaware invoking queue for listening the router changing action